### PR TITLE
Add email address

### DIFF
--- a/LinkedInStrategy.php
+++ b/LinkedInStrategy.php
@@ -131,6 +131,7 @@ class LinkedInStrategy extends OpauthStrategy{
 					$this->mapProfile($profile, 'formatted-name', 'info.name');
 					$this->mapProfile($profile, 'first-name', 'info.first_name');
 					$this->mapProfile($profile, 'last-name', 'info.last_name');
+					$this->mapProfile($profile, 'email-address', 'info.email');
 					$this->mapProfile($profile, 'headline', 'info.headline');
 					$this->mapProfile($profile, 'summary', 'info.description');
 					$this->mapProfile($profile, 'location.name', 'info.location');


### PR DESCRIPTION
By using the right scope we have access to user's email:

``` php
// Using LinkedIn strategy for Opauth
Configure::write('Opauth.Strategy.LinkedIn', array(
    'api_key' => 'XXXX',
    'secret_key' => 'XXXX',
    'scope' => 'r_basicprofile r_emailaddress',
    'profile_fields' => array('id', 'first-name', 'last-name', 'formatted-name', 'headline', 'picture-url', 'summary', 'location', 'public-profile-url', 'site-standard-profile-request', 'email-address')
));
```
